### PR TITLE
fix(ci): update lockfile to wrap-ansi@9.0.2 (npm 404)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5201,9 +5201,9 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.1.tgz",
-      "integrity": "sha512-n84lsZmcV2vUTRThlsxQhujZcDja2KIPCsEKZYP04cGtceS1vXTCboD7/zIJcZgEL9r3PdYrIX5KqX/DDWyMKw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",


### PR DESCRIPTION
CI was failing with:\n\n> 404 Not Found - GET https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.1.tgz\n\nIt appears wrap-ansi@9.0.1 tarball has been yanked. This updates package-lock.json to resolve wrap-ansi to 9.0.2 (latest), with the correct tarball URL and integrity.\n\nThis should unblock the Pages build job.