### PR TITLE
fix(ci): lockfile updates for yanked tarballs (strip-ansi@7.1.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4765,9 +4765,9 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.1.tgz",
-      "integrity": "sha512-6nC4zf74oXgXJSDmtrIbNXdY5jjLBukH4WN4UC7IC8lX2pUbFvC9n761PhQZt1TPBquz68g3H23O/KkRDOq3Lw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },


### PR DESCRIPTION
Follow-up to resolve further npm 404s.\n\n- strip-ansi@7.1.1 tarball returns 404 from registry\n- Update package-lock entry to 7.1.2 (latest) with correct integrity\n\nAfter merge, Pages build should proceed. If more yanked tarballs surface, we will bump those similarly.