### PR TITLE
fix(ci): lockfile bump chalk@5.6.2 (avoid yanked 5.6.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1995,9 +1995,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.1.tgz",
-      "integrity": "sha512-5b8G5vAwZY6ae5Vrp8HcIip49h0n88ASWNfK02h9aUjdPdhac481t5Ry7wXamd0gUvyK1KvS/dePAwAkEms4pw==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },


### PR DESCRIPTION
Pages build failed due to npm 404 on chalk@5.6.1 (tarball missing).\n\nUpdate package-lock.json entry to 5.6.2 (latest) with correct integrity.