### PR TITLE
ci: fallback to npm install without lockfile when npm ci fails

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,8 +29,11 @@ jobs:
       - run: npm config set fetch-retry-mintimeout 20000
       - run: npm config set fetch-retry-maxtimeout 120000
 
-      # lockが不安定なら一時的に install に固定してOK（あとで戻せば良い）
-      - run: npm install --no-audit --prefer-online
+      # lockfileの特定tarball 404に備えて、ci失敗時はロック無視でインストール
+      - name: Install dependencies
+        run: |
+          npm ci --no-audit --prefer-online \
+          || npm install --no-audit --prefer-online --package-lock=false
       - run: npm run build
 
       - name: Upload artifact


### PR DESCRIPTION
NPM registry has yanked several tarballs (e.g., wrap-ansi@9.0.1, strip-ansi@7.1.1, chalk@5.6.1), causing CI to fail with 404s.

This updates the Pages workflow to:
- Try `npm ci --no-audit --prefer-online` first
- If it fails, fall back to `npm install --no-audit --prefer-online --package-lock=false`

This keeps builds unblocked while the ecosystem stabilizes. We can revert to pure `npm ci` later.
