### PR TITLE
feat(ux): スマホ最適化・次発を大きく表示＋カウントダウン・相対時刻表記

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,16 +1,32 @@
 :root { --bg:#0b0d10;--card:#12161b;--border:#1f2630;--text:#e6edf3;--muted:#9aa7b3;--chip:#19202a;--accent:#2f81f7 }
-*{box-sizing:border-box}html,body{height:100%}body{margin:0;background:var(--bg);color:var(--text);font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Noto Sans JP,sans-serif}
+*{box-sizing:border-box}html,body{height:100%}
+body{margin:0;background:var(--bg);color:var(--text);font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Noto Sans JP,sans-serif}
+@media (max-width: 480px){ body{ font-size:17px; } }
 .container{max-width:960px;margin:0 auto;padding:16px}
-header h1{margin:16px 0 4px;font-weight:800;letter-spacing:.02em}.muted{color:var(--muted)}
+header h1{margin:16px 0 4px;font-weight:800;letter-spacing:.02em}
+.muted{color:var(--muted)}
 .card{background:var(--card);border:1px solid var(--border);border-radius:16px;box-shadow:0 6px 24px rgba(0,0,0,.25)}
-.controls{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));padding:16px;border-bottom:1px solid var(--border)}
+.controls{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));padding:16px;border-bottom:1px solid var(--border)}
 .control label{display:block;font-size:12px;color:var(--muted);margin-bottom:6px}
-select,input[type=time]{width:100%;padding:10px 12px;border-radius:10px;background:#0f1318;color:var(--text);border:1px solid var(--border)}
-.ghost{margin-top:8px;padding:8px 10px;background:transparent;color:var(--muted);border:1px dashed var(--border);border-radius:8px;cursor:pointer}
-.summary{display:flex;gap:8px;flex-wrap:wrap;padding:16px}.chip{background:var(--chip);border:1px solid var(--border);padding:6px 10px;border-radius:999px;font-size:12px;color:var(--muted)}
-.results{padding:8px 16px 16px}.results h2{margin:12px 0 8px;font-size:16px}
+select,input[type=time]{width:100%;padding:12px 14px;border-radius:12px;background:#0f1318;color:var(--text);border:1px solid var(--border);min-height:44px}
+.ghost{margin-top:8px;padding:10px 12px;background:transparent;color:var(--muted);border:1px dashed var(--border);border-radius:10px;cursor:pointer;min-height:44px}
+.summary{display:flex;gap:8px;flex-wrap:wrap;padding:16px}
+.chip{background:var(--chip);border:1px solid var(--border);padding:8px 12px;border-radius:999px;font-size:12px;color:var(--muted)}
+.results{padding:8px 16px 16px}
+.results h2{margin:12px 0 8px;font-size:16px}
 .trip{border:1px solid var(--border);border-radius:12px;padding:12px;background:#0f1318}
-.tripRow{display:grid;grid-template-columns:1fr auto;gap:8px;align-items:center;padding:6px 0}
+.tripRow{display:grid;grid-template-columns:1fr auto;gap:8px;align-items:center;padding:8px 0}
 .badge{font-size:12px;padding:2px 8px;border-radius:999px;border:1px solid var(--border);color:var(--muted)}
-.time{font-feature-settings:"tnum" 1,"liga" 0;letter-spacing:.02em}.kicker{font-size:12px;color:var(--muted)}
+.badge--relative{font-variant-numeric: tabular-nums;}
+.time{font-feature-settings:"tnum" 1,"liga" 0;letter-spacing:.02em}
+.kicker{font-size:12px;color:var(--muted)}
 .footer{display:flex;justify-content:space-between;align-items:center;color:var(--muted)}
+
+/* Hero (次発を強調表示) */
+.hero{display:grid;place-items:center;text-align:center;border:1px solid var(--border);border-radius:14px;padding:18px;background:linear-gradient(180deg,rgba(47,129,247,.12),rgba(47,129,247,0));margin:8px 0 16px}
+.hero-time{font-size:clamp(44px,10vw,72px);font-weight:800;letter-spacing:.02em}
+.countdown{margin-top:4px;color:var(--muted);font-variant-numeric:tabular-nums;letter-spacing:.04em}
+.hero-sub{margin-top:8px;color:var(--text)}
+
+/* a11y: visually hidden */
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}


### PR DESCRIPTION
UX改善を実施しました。\n\n- スマホ向け調整: 入力/選択UIのタップターゲット拡大、フォントサイズ微調整\n- 次発(アクティブ)を中央のヒーローカードで強調\n  - 出発までのカウントダウン(HH:MM:SS)を追加\n- 以降の便: ‘hh時間mm分後’ の相対表記に統一\n- スタイル: hero / countdown / sr-only など追加\n\n必要に応じてカウントダウン表記やサイズを微調整します。