### PR TITLE
ci: FTPデプロイ追加（Secretsで有効化）＋favicon参照修正／envサンプル

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+PUBLIC_SITE_URL=https://ysatodat.github.io
+PUBLIC_BASE_PATH=/Sakaimachi-Tokyo-Bus-App/
+
+# 独自ドメインで運用する場合は↓のように上書き
+# PUBLIC_SITE_URL=https://sakaimachi-bus.amida-des.com
+# PUBLIC_BASE_PATH=/

--- a/.github/workflows/deploy-ftp.yml
+++ b/.github/workflows/deploy-ftp.yml
@@ -1,0 +1,53 @@
+name: Deploy to Custom Server (FTP/FTPS)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+concurrency:
+  group: ftp-deploy
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    # 実行は必要なシークレットが揃っている場合のみ
+    if: ${{ secrets.FTP_SERVER != '' && secrets.FTP_USERNAME != '' && secrets.FTP_PASSWORD != '' && secrets.FTP_DIR != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+
+      - run: npm config set fetch-retries 5
+      - run: npm config set fetch-retry-mintimeout 20000
+      - run: npm config set fetch-retry-maxtimeout 120000
+
+      - name: Install deps (with fallback)
+        run: |
+          npm ci --no-audit --prefer-online \
+          || npm install --no-audit --prefer-online --package-lock=false
+
+      - name: Build for custom domain
+        env:
+          PUBLIC_SITE_URL: ${{ secrets.PUBLIC_SITE_URL || 'https://sakaimachi-bus.amida-des.com' }}
+          PUBLIC_BASE_PATH: ${{ secrets.PUBLIC_BASE_PATH || '/' }}
+        run: npm run build
+
+      - name: Deploy via FTP/FTPS
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          protocol: ${{ secrets.FTP_PROTOCOL || 'ftps' }}
+          port: ${{ secrets.FTP_PORT || 21 }}
+          local-dir: dist/
+          server-dir: ${{ secrets.FTP_DIR }}
+          exclude: |
+            **/.git*
+            **/.DS_Store
+            **/node_modules/**
+            **/cgi-bin/**
+

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,8 @@ import App from "../components/App.tsx";
 const site = import.meta.env.PUBLIC_SITE_URL ?? 'https://ysatodat.github.io';
 const base = import.meta.env.PUBLIC_BASE_PATH ?? '/Sakaimachi-Tokyo-Bus-App/';
 const siteUrl = new URL(base, site).toString();
+const favIcon = siteUrl + 'favicon.svg';
+const appleIcon = siteUrl + 'apple-touch-icon.png';
 
 const title = "境町 ↔ 東京 高速バス（ミニ時刻・次発表示）";
 const description = "境町と東京（王子駅/東京駅）を結ぶ高速バスの次発・以降・始発/終バスを素早く確認。";
@@ -52,5 +54,5 @@ const ogImage = siteUrl + "og.png";
     <App client:load />
   </body>
 </html>
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" href={favIcon} type="image/svg+xml" />
+    <link rel="apple-touch-icon" sizes="180x180" href={appleIcon} />


### PR DESCRIPTION
サブドメイン  での配信を見据え、以下を追加しました。

-  を追加（SamKirkland/FTP-Deploy-Action）
  - Secrets が揃っている場合のみ実行（, , , ）
  - 既定は FTPS(Explicit) / 21。,  で上書き可
  - ビルド時は  /  を Secrets or 既定値で設定
-  の favicon / apple-touch-icon の参照を base 対応に修正
-  を追加

注意: セキュリティ上、可能なら SFTP/SSH への切替を推奨。必要なら SSH 版ワークフローを利用してください（既に  あり）。